### PR TITLE
Fixed Module name

### DIFF
--- a/Source/SimpleActions/Private/SimpleActionsModule.cpp
+++ b/Source/SimpleActions/Private/SimpleActionsModule.cpp
@@ -14,4 +14,4 @@ void FSimpleActionsModule::ShutdownModule()
 
 #undef LOCTEXT_NAMESPACE
 	
-IMPLEMENT_MODULE(FSimpleActionsModule, SimpleActionsModule)
+IMPLEMENT_MODULE(FSimpleActionsModule, SimpleActions)


### PR DESCRIPTION
Removed "Module" postfix on module name, this prevented the module from being mounted properly in a build version of the plugin.